### PR TITLE
feat: add storefront gallery with admin CRUD

### DIFF
--- a/packages/admin/src/components/AdminLayout.tsx
+++ b/packages/admin/src/components/AdminLayout.tsx
@@ -51,6 +51,7 @@ const navItems: NavItem[] = [
       { path: '/design/branding', label: 'Branding' },
       { path: '/design/theme', label: 'Theme' },
       { path: '/design/templates', label: 'Templates' },
+      { path: '/design/gallery', label: 'Gallery' },
     ],
   },
   {

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -34,6 +34,7 @@ import DesignLanding from './pages/DesignLanding.js';
 import DesignBranding from './pages/DesignBranding.js';
 import DesignTheme from './pages/DesignTheme.js';
 import DesignTemplates from './pages/DesignTemplates.js';
+import DesignGallery from './pages/DesignGallery.js';
 import StaffList from './pages/StaffList.js';
 import StaffInvite from './pages/StaffInvite.js';
 import StaffEdit from './pages/StaffEdit.js';
@@ -108,6 +109,7 @@ function AppRoutes() {
         <Route path="/design/branding" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignBranding /></RequireRole>} />
         <Route path="/design/theme" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignTheme /></RequireRole>} />
         <Route path="/design/templates" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignTemplates /></RequireRole>} />
+        <Route path="/design/gallery" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignGallery /></RequireRole>} />
         <Route path="/legal" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><Navigate to="/legal/pages" replace /></RequireRole>} />
         <Route path="/legal/pages" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><LegalPageList /></RequireRole>} />
         <Route path="/legal/pages/:slug" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><LegalPageForm /></RequireRole>} />

--- a/packages/admin/src/pages/DesignGallery.tsx
+++ b/packages/admin/src/pages/DesignGallery.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useState } from 'react';
+
+type Category = 'FOOD' | 'INTERIOR' | 'GARDEN' | 'EVENTS';
+
+interface GalleryImage {
+  id: string;
+  url: string;
+  alt: string;
+  category: Category;
+  sortOrder: number;
+  isActive: boolean;
+}
+
+const CATEGORIES: Category[] = ['FOOD', 'INTERIOR', 'GARDEN', 'EVENTS'];
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  FOOD: 'Food',
+  INTERIOR: 'Interior',
+  GARDEN: 'Garden',
+  EVENTS: 'Events',
+};
+
+interface FormState {
+  url: string;
+  alt: string;
+  category: Category;
+  sortOrder: number;
+  isActive: boolean;
+}
+
+const emptyForm: FormState = {
+  url: '',
+  alt: '',
+  category: 'FOOD',
+  sortOrder: 0,
+  isActive: true,
+};
+
+export default function DesignGallery() {
+  const [images, setImages] = useState<GalleryImage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [filter, setFilter] = useState<Category | 'ALL'>('ALL');
+  const [editing, setEditing] = useState<GalleryImage | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [saving, setSaving] = useState(false);
+
+  const token = localStorage.getItem('token') || '';
+  const authHeaders = { Authorization: `Bearer ${token}` };
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/gallery/admin', { headers: authHeaders });
+      if (!res.ok) throw new Error('Failed to load gallery');
+      const result = await res.json();
+      setImages(result.data ?? []);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  function openCreate() {
+    setEditing(null);
+    setForm(emptyForm);
+    setShowForm(true);
+  }
+
+  function openEdit(img: GalleryImage) {
+    setEditing(img);
+    setForm({
+      url: img.url,
+      alt: img.alt,
+      category: img.category,
+      sortOrder: img.sortOrder,
+      isActive: img.isActive,
+    });
+    setShowForm(true);
+  }
+
+  function closeForm() {
+    setShowForm(false);
+    setEditing(null);
+    setForm(emptyForm);
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const url = editing ? `/api/gallery/${editing.id}` : '/api/gallery';
+      const method = editing ? 'PATCH' : 'POST';
+      const res = await fetch(url, {
+        method,
+        headers: { ...authHeaders, 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) {
+        const result = await res.json().catch(() => ({}));
+        throw new Error(result.error?.[0]?.message || 'Save failed');
+      }
+      closeForm();
+      await load();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove(img: GalleryImage) {
+    if (!window.confirm(`Delete "${img.alt}"?`)) return;
+    const res = await fetch(`/api/gallery/${img.id}`, { method: 'DELETE', headers: authHeaders });
+    if (res.ok) await load();
+    else setError('Delete failed');
+  }
+
+  async function toggleActive(img: GalleryImage) {
+    const res = await fetch(`/api/gallery/${img.id}`, {
+      method: 'PATCH',
+      headers: { ...authHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isActive: !img.isActive }),
+    });
+    if (res.ok) await load();
+  }
+
+  const filtered = filter === 'ALL' ? images : images.filter((i) => i.category === filter);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-800">Gallery</h2>
+          <p className="text-sm text-gray-500 mt-1">Manage photos shown on the storefront gallery page</p>
+        </div>
+        <button
+          onClick={openCreate}
+          className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors"
+        >
+          + Add Image
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {(['ALL', ...CATEGORIES] as const).map((c) => (
+          <button
+            key={c}
+            onClick={() => setFilter(c)}
+            className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
+              filter === c ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            {c === 'ALL' ? 'All' : CATEGORY_LABELS[c]}
+            <span className="ml-1 opacity-70">
+              ({c === 'ALL' ? images.length : images.filter((i) => i.category === c).length})
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {error && <div className="bg-red-50 text-red-700 p-3 rounded-lg mb-4 text-sm">{error}</div>}
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <div className="w-8 h-8 border-4 border-primary-200 border-t-primary-600 rounded-full animate-spin" />
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-gray-500 text-sm py-8 text-center">No images yet. Click "Add Image" to start.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {filtered.map((img) => (
+            <div key={img.id} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+              <div className="aspect-[4/3] bg-gray-100 relative">
+                <img src={img.url} alt={img.alt} className="w-full h-full object-cover" loading="lazy" />
+                {!img.isActive && (
+                  <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                    <span className="text-white text-xs font-semibold bg-gray-800 px-2 py-1 rounded">HIDDEN</span>
+                  </div>
+                )}
+              </div>
+              <div className="p-3">
+                <p className="text-sm font-medium text-gray-900 truncate" title={img.alt}>{img.alt}</p>
+                <div className="flex items-center justify-between mt-1">
+                  <span className="text-xs text-gray-500">{CATEGORY_LABELS[img.category]} · #{img.sortOrder}</span>
+                </div>
+                <div className="flex gap-2 mt-3">
+                  <button
+                    onClick={() => openEdit(img)}
+                    className="flex-1 text-xs px-2 py-1.5 border border-gray-300 rounded hover:bg-gray-50"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => toggleActive(img)}
+                    className="flex-1 text-xs px-2 py-1.5 border border-gray-300 rounded hover:bg-gray-50"
+                  >
+                    {img.isActive ? 'Hide' : 'Show'}
+                  </button>
+                  <button
+                    onClick={() => remove(img)}
+                    className="text-xs px-2 py-1.5 border border-red-200 text-red-600 rounded hover:bg-red-50"
+                    aria-label={`Delete ${img.alt}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showForm && (
+        <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full">
+            <form onSubmit={save}>
+              <div className="p-6 border-b border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-900">{editing ? 'Edit Image' : 'Add Image'}</h3>
+              </div>
+              <div className="p-6 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Image URL</label>
+                  <input
+                    type="url"
+                    required
+                    value={form.url}
+                    onChange={(e) => setForm({ ...form, url: e.target.value })}
+                    placeholder="https://..."
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                  />
+                </div>
+                {form.url && (
+                  <div className="aspect-[4/3] bg-gray-100 rounded-lg overflow-hidden">
+                    <img src={form.url} alt="preview" className="w-full h-full object-cover" />
+                  </div>
+                )}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Alt text</label>
+                  <input
+                    type="text"
+                    required
+                    maxLength={200}
+                    value={form.alt}
+                    onChange={(e) => setForm({ ...form, alt: e.target.value })}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
+                    <select
+                      value={form.category}
+                      onChange={(e) => setForm({ ...form, category: e.target.value as Category })}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+                    >
+                      {CATEGORIES.map((c) => (
+                        <option key={c} value={c}>{CATEGORY_LABELS[c]}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Sort order</label>
+                    <input
+                      type="number"
+                      value={form.sortOrder}
+                      onChange={(e) => setForm({ ...form, sortOrder: parseInt(e.target.value) || 0 })}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                    />
+                  </div>
+                </div>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={form.isActive}
+                    onChange={(e) => setForm({ ...form, isActive: e.target.checked })}
+                    className="rounded"
+                  />
+                  <span className="text-sm text-gray-700">Visible on storefront</span>
+                </label>
+              </div>
+              <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end gap-2 rounded-b-xl">
+                <button
+                  type="button"
+                  onClick={closeForm}
+                  className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-100"
+                  disabled={saving}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50"
+                  disabled={saving}
+                >
+                  {saving ? 'Saving...' : editing ? 'Save Changes' : 'Add Image'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/server/src/__tests__/integration/gallery.test.ts
+++ b/packages/server/src/__tests__/integration/gallery.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../app.js';
+import { generateToken } from '../../middleware/auth.js';
+
+vi.mock('../../lib/db.js', () => {
+  const mockPrisma = {
+    galleryImage: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn(), count: vi.fn() },
+    user: { findUnique: vi.fn() },
+    customer: { findUnique: vi.fn() },
+  };
+  return { default: mockPrisma, prisma: mockPrisma };
+});
+
+vi.mock('../../lib/stripe.js', () => ({
+  default: {
+    paymentIntents: { create: vi.fn() },
+    webhooks: { constructEvent: vi.fn() },
+  },
+}));
+
+import prisma from '../../lib/db.js';
+const mockedPrisma = vi.mocked(prisma);
+
+const app = createApp();
+
+const staffToken = generateToken({ id: '1', email: 'admin@test.com', type: 'staff', role: 'SUPER_ADMIN' });
+const customerToken = generateToken({ id: 'cust-1', email: 'customer@test.com', type: 'customer' });
+
+const sampleImage = {
+  id: 'img-1',
+  url: 'https://example.com/photo.jpg',
+  alt: 'Test photo',
+  category: 'FOOD',
+  sortOrder: 0,
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Gallery API', () => {
+  describe('GET /api/gallery (public)', () => {
+    it('returns active images without auth', async () => {
+      mockedPrisma.galleryImage.findMany.mockResolvedValueOnce([sampleImage] as any);
+      const res = await request(app).get('/api/gallery');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].category).toBe('FOOD');
+      // Verify only active images are returned
+      const where = mockedPrisma.galleryImage.findMany.mock.calls[0][0]?.where;
+      expect(where).toMatchObject({ isActive: true });
+    });
+
+    it('filters by category', async () => {
+      mockedPrisma.galleryImage.findMany.mockResolvedValueOnce([sampleImage] as any);
+      const res = await request(app).get('/api/gallery?category=FOOD');
+      expect(res.status).toBe(200);
+      const where = mockedPrisma.galleryImage.findMany.mock.calls[0][0]?.where;
+      expect(where).toMatchObject({ isActive: true, category: 'FOOD' });
+    });
+
+    it('ignores invalid category filter', async () => {
+      mockedPrisma.galleryImage.findMany.mockResolvedValueOnce([] as any);
+      const res = await request(app).get('/api/gallery?category=BOGUS');
+      expect(res.status).toBe(200);
+      const where = mockedPrisma.galleryImage.findMany.mock.calls[0][0]?.where;
+      expect(where).toMatchObject({ isActive: true });
+      expect((where as any).category).toBeUndefined();
+    });
+  });
+
+  describe('GET /api/gallery/admin', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app).get('/api/gallery/admin');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .get('/api/gallery/admin')
+        .set('Authorization', `Bearer ${customerToken}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns full list (including hidden) for staff', async () => {
+      mockedPrisma.galleryImage.findMany.mockResolvedValueOnce([
+        sampleImage,
+        { ...sampleImage, id: 'img-2', isActive: false },
+      ] as any);
+      const res = await request(app)
+        .get('/api/gallery/admin')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+      // No isActive filter on admin endpoint
+      const where = mockedPrisma.galleryImage.findMany.mock.calls[0][0]?.where;
+      expect(where).toBeUndefined();
+    });
+  });
+
+  describe('POST /api/gallery', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app).post('/api/gallery').send({
+        url: 'https://example.com/x.jpg', alt: 'x', category: 'FOOD',
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .post('/api/gallery')
+        .set('Authorization', `Bearer ${customerToken}`)
+        .send({ url: 'https://example.com/x.jpg', alt: 'x', category: 'FOOD' });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 400 for invalid url', async () => {
+      const res = await request(app)
+        .post('/api/gallery')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .send({ url: 'not-a-url', alt: 'x', category: 'FOOD' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid category', async () => {
+      const res = await request(app)
+        .post('/api/gallery')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .send({ url: 'https://example.com/x.jpg', alt: 'x', category: 'BOGUS' });
+      expect(res.status).toBe(400);
+    });
+
+    it('creates image successfully', async () => {
+      mockedPrisma.galleryImage.create.mockResolvedValueOnce(sampleImage as any);
+      const res = await request(app)
+        .post('/api/gallery')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .send({ url: 'https://example.com/photo.jpg', alt: 'Test photo', category: 'FOOD' });
+      expect(res.status).toBe(201);
+      expect(res.body.data.id).toBe('img-1');
+    });
+  });
+
+  describe('PATCH /api/gallery/:id', () => {
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .patch('/api/gallery/img-1')
+        .set('Authorization', `Bearer ${customerToken}`)
+        .send({ alt: 'updated' });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when not found', async () => {
+      mockedPrisma.galleryImage.findUnique.mockResolvedValueOnce(null);
+      const res = await request(app)
+        .patch('/api/gallery/bad-id')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .send({ alt: 'updated' });
+      expect(res.status).toBe(404);
+    });
+
+    it('updates fields successfully', async () => {
+      mockedPrisma.galleryImage.findUnique.mockResolvedValueOnce(sampleImage as any);
+      mockedPrisma.galleryImage.update.mockResolvedValueOnce({ ...sampleImage, alt: 'updated' } as any);
+      const res = await request(app)
+        .patch('/api/gallery/img-1')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .send({ alt: 'updated' });
+      expect(res.status).toBe(200);
+      expect(res.body.data.alt).toBe('updated');
+    });
+  });
+
+  describe('DELETE /api/gallery/:id', () => {
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .delete('/api/gallery/img-1')
+        .set('Authorization', `Bearer ${customerToken}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when not found', async () => {
+      mockedPrisma.galleryImage.findUnique.mockResolvedValueOnce(null);
+      const res = await request(app)
+        .delete('/api/gallery/bad-id')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('deletes image', async () => {
+      mockedPrisma.galleryImage.findUnique.mockResolvedValueOnce(sampleImage as any);
+      mockedPrisma.galleryImage.delete.mockResolvedValueOnce(sampleImage as any);
+      const res = await request(app)
+        .delete('/api/gallery/img-1')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,6 +21,7 @@ import consentRoutes from './routes/consent.routes.js';
 import settingsRoutes from './routes/settings.routes.js';
 import staffRoutes from './routes/staff.routes.js';
 import developerRoutes from './routes/developer.routes.js';
+import galleryRoutes from './routes/gallery.routes.js';
 import { openApiSpec } from './lib/openapi.js';
 import { initPassport } from './lib/passport.js';
 import passport from 'passport';
@@ -117,6 +118,7 @@ export function createApp() {
   app.use('/api/settings', settingsRoutes);
   app.use('/api/staff', staffRoutes);
   app.use('/api/developer', developerRoutes);
+  app.use('/api/gallery', galleryRoutes);
 
   // 404 handler
   app.use((_req, res) => {

--- a/packages/server/src/controllers/gallery.controller.ts
+++ b/packages/server/src/controllers/gallery.controller.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import prisma from '../lib/db.js';
+
+const CATEGORIES = ['FOOD', 'INTERIOR', 'GARDEN', 'EVENTS'] as const;
+
+const createSchema = z.object({
+  url: z.string().url().max(2048),
+  alt: z.string().min(1).max(200),
+  category: z.enum(CATEGORIES),
+  sortOrder: z.number().int().optional(),
+  isActive: z.boolean().optional(),
+});
+
+const updateSchema = createSchema.partial();
+
+export async function listPublicGallery(req: Request, res: Response): Promise<void> {
+  const category = req.query.category as string | undefined;
+  const where: Record<string, unknown> = { isActive: true };
+  if (category && (CATEGORIES as readonly string[]).includes(category)) {
+    where.category = category;
+  }
+
+  const images = await prisma.galleryImage.findMany({
+    where,
+    orderBy: [{ category: 'asc' }, { sortOrder: 'asc' }, { createdAt: 'asc' }],
+  });
+
+  res.json({ success: true, data: images });
+}
+
+export async function listAllGallery(_req: Request, res: Response): Promise<void> {
+  const images = await prisma.galleryImage.findMany({
+    orderBy: [{ category: 'asc' }, { sortOrder: 'asc' }, { createdAt: 'asc' }],
+  });
+  res.json({ success: true, data: images });
+}
+
+export async function createGalleryImage(req: Request, res: Response): Promise<void> {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ success: false, error: parsed.error.errors });
+    return;
+  }
+
+  const image = await prisma.galleryImage.create({
+    data: {
+      url: parsed.data.url,
+      alt: parsed.data.alt,
+      category: parsed.data.category,
+      sortOrder: parsed.data.sortOrder ?? 0,
+      isActive: parsed.data.isActive ?? true,
+    },
+  });
+
+  res.status(201).json({ success: true, data: image });
+}
+
+export async function updateGalleryImage(req: Request<{ id: string }>, res: Response): Promise<void> {
+  const parsed = updateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ success: false, error: parsed.error.errors });
+    return;
+  }
+
+  const existing = await prisma.galleryImage.findUnique({ where: { id: req.params.id } });
+  if (!existing) {
+    res.status(404).json({ success: false, error: 'Image not found' });
+    return;
+  }
+
+  const image = await prisma.galleryImage.update({
+    where: { id: req.params.id },
+    data: parsed.data,
+  });
+
+  res.json({ success: true, data: image });
+}
+
+export async function deleteGalleryImage(req: Request<{ id: string }>, res: Response): Promise<void> {
+  const existing = await prisma.galleryImage.findUnique({ where: { id: req.params.id } });
+  if (!existing) {
+    res.status(404).json({ success: false, error: 'Image not found' });
+    return;
+  }
+
+  await prisma.galleryImage.delete({ where: { id: req.params.id } });
+  res.json({ success: true, message: 'Image deleted' });
+}

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { authenticate, requireStaff } from '../middleware/auth.js';
+import {
+  listPublicGallery,
+  listAllGallery,
+  createGalleryImage,
+  updateGalleryImage,
+  deleteGalleryImage,
+} from '../controllers/gallery.controller.js';
+
+const router = Router();
+
+// Public: list active gallery images (optionally filtered by category)
+router.get('/', listPublicGallery);
+
+// Staff: full list + CRUD
+router.get('/admin', authenticate, requireStaff, listAllGallery);
+router.post('/', authenticate, requireStaff, createGalleryImage);
+router.patch('/:id', authenticate, requireStaff, updateGalleryImage);
+router.delete('/:id', authenticate, requireStaff, deleteGalleryImage);
+
+export default router;

--- a/packages/storefront/src/components/Header.tsx
+++ b/packages/storefront/src/components/Header.tsx
@@ -20,6 +20,7 @@ function ClassicHeader() {
     { to: '/', label: t('nav.home') },
     { to: '/locations', label: t('nav.locations') },
     { to: '/menu', label: t('nav.menu') },
+    { to: '/gallery', label: t('nav.gallery') },
     { to: '/reservations', label: t('nav.reservations') },
   ];
 

--- a/packages/storefront/src/i18n/locales/de.json
+++ b/packages/storefront/src/i18n/locales/de.json
@@ -18,12 +18,23 @@
     "locations": "Standorte",
     "menu": "Speisekarte",
     "reservations": "Reservierungen",
+    "gallery": "Galerie",
     "login": "Anmelden",
     "signUp": "Registrieren",
     "logout": "Abmelden",
     "myAccount": "Mein Konto",
     "openCart": "Warenkorb öffnen",
     "toggleMenu": "Menü umschalten"
+  },
+  "gallery": {
+    "title": "Galerie",
+    "subtitle": "Ein Blick in unser Restaurant — Küche, Ambiente, Garten und besondere Momente",
+    "all": "Alle",
+    "food": "Speisen",
+    "interior": "Innenbereich",
+    "garden": "Garten",
+    "events": "Events",
+    "empty": "Noch keine Fotos."
   },
   "home": {
     "heroTitle": "Leckeres Essen Online Bestellen",

--- a/packages/storefront/src/i18n/locales/en.json
+++ b/packages/storefront/src/i18n/locales/en.json
@@ -18,12 +18,23 @@
     "locations": "Locations",
     "menu": "Menu",
     "reservations": "Reservations",
+    "gallery": "Gallery",
     "login": "Login",
     "signUp": "Sign Up",
     "logout": "Logout",
     "myAccount": "My Account",
     "openCart": "Open cart",
     "toggleMenu": "Toggle menu"
+  },
+  "gallery": {
+    "title": "Gallery",
+    "subtitle": "A peek inside our restaurant — food, ambiance, garden and special moments",
+    "all": "All",
+    "food": "Food",
+    "interior": "Interior",
+    "garden": "Garden",
+    "events": "Events",
+    "empty": "No photos yet."
   },
   "home": {
     "heroTitle": "Order Delicious Food Online",

--- a/packages/storefront/src/i18n/locales/es.json
+++ b/packages/storefront/src/i18n/locales/es.json
@@ -18,12 +18,23 @@
     "locations": "Ubicaciones",
     "menu": "Menú",
     "reservations": "Reservas",
+    "gallery": "Galería",
     "login": "Iniciar Sesión",
     "signUp": "Registrarse",
     "logout": "Cerrar Sesión",
     "myAccount": "Mi Cuenta",
     "openCart": "Abrir carrito",
     "toggleMenu": "Alternar menú"
+  },
+  "gallery": {
+    "title": "Galería",
+    "subtitle": "Una mirada dentro de nuestro restaurante — comida, ambiente, jardín y momentos especiales",
+    "all": "Todo",
+    "food": "Comida",
+    "interior": "Interior",
+    "garden": "Jardín",
+    "events": "Eventos",
+    "empty": "Aún no hay fotos."
   },
   "home": {
     "heroTitle": "Pide Comida Deliciosa en Línea",

--- a/packages/storefront/src/i18n/locales/fr.json
+++ b/packages/storefront/src/i18n/locales/fr.json
@@ -18,12 +18,23 @@
     "locations": "Restaurants",
     "menu": "Menu",
     "reservations": "Réservations",
+    "gallery": "Galerie",
     "login": "Connexion",
     "signUp": "S'inscrire",
     "logout": "Déconnexion",
     "myAccount": "Mon Compte",
     "openCart": "Ouvrir le panier",
     "toggleMenu": "Basculer le menu"
+  },
+  "gallery": {
+    "title": "Galerie",
+    "subtitle": "Un aperçu de notre restaurant — cuisine, ambiance, jardin et moments d'exception",
+    "all": "Tout",
+    "food": "Cuisine",
+    "interior": "Intérieur",
+    "garden": "Jardin",
+    "events": "Événements",
+    "empty": "Aucune photo pour le moment."
   },
   "home": {
     "heroTitle": "Commandez de Bons Plats en Ligne",

--- a/packages/storefront/src/i18n/locales/it.json
+++ b/packages/storefront/src/i18n/locales/it.json
@@ -18,12 +18,23 @@
     "locations": "Sedi",
     "menu": "Menu",
     "reservations": "Prenotazioni",
+    "gallery": "Galleria",
     "login": "Accedi",
     "signUp": "Registrati",
     "logout": "Esci",
     "myAccount": "Il Mio Account",
     "openCart": "Apri carrello",
     "toggleMenu": "Apri/chiudi menu"
+  },
+  "gallery": {
+    "title": "Galleria",
+    "subtitle": "Uno sguardo dentro il nostro ristorante — cucina, atmosfera, giardino e momenti speciali",
+    "all": "Tutto",
+    "food": "Cucina",
+    "interior": "Interno",
+    "garden": "Giardino",
+    "events": "Eventi",
+    "empty": "Ancora nessuna foto."
   },
   "home": {
     "heroTitle": "Ordina Cibo Delizioso Online",

--- a/packages/storefront/src/i18n/locales/pt.json
+++ b/packages/storefront/src/i18n/locales/pt.json
@@ -18,12 +18,23 @@
     "locations": "Localizações",
     "menu": "Cardápio",
     "reservations": "Reservas",
+    "gallery": "Galeria",
     "login": "Entrar",
     "signUp": "Cadastrar",
     "logout": "Sair",
     "myAccount": "Minha Conta",
     "openCart": "Abrir carrinho",
     "toggleMenu": "Alternar menu"
+  },
+  "gallery": {
+    "title": "Galeria",
+    "subtitle": "Um vislumbre do nosso restaurante — comida, ambiente, jardim e momentos especiais",
+    "all": "Tudo",
+    "food": "Comida",
+    "interior": "Interior",
+    "garden": "Jardim",
+    "events": "Eventos",
+    "empty": "Ainda sem fotos."
   },
   "home": {
     "heroTitle": "Peça Comida Deliciosa Online",

--- a/packages/storefront/src/main.tsx
+++ b/packages/storefront/src/main.tsx
@@ -14,6 +14,7 @@ import Menu from './pages/Menu.js';
 import Checkout from './pages/Checkout.js';
 import OrderConfirmation from './pages/OrderConfirmation.js';
 import Reservations from './pages/Reservations.js';
+import Gallery from './pages/Gallery.js';
 import OrderHistory from './pages/OrderHistory.js';
 import OrderStatus from './pages/OrderStatus.js';
 import AuthCallback from './pages/AuthCallback.js';
@@ -35,6 +36,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route path="/locations" element={<Locations />} />
             <Route path="/menu" element={<Menu />} />
             <Route path="/reservations" element={<Reservations />} />
+            <Route path="/gallery" element={<Gallery />} />
             <Route path="/checkout" element={<Checkout />} />
             <Route path="/order/:id" element={<OrderConfirmation />} />
             <Route path="/login" element={<Login />} />

--- a/packages/storefront/src/pages/Gallery.tsx
+++ b/packages/storefront/src/pages/Gallery.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useApi } from '../hooks/useApi.js';
+
+type GalleryCategory = 'FOOD' | 'INTERIOR' | 'GARDEN' | 'EVENTS';
+
+interface GalleryImage {
+  id: string;
+  url: string;
+  alt: string;
+  category: GalleryCategory;
+  sortOrder: number;
+}
+
+type Filter = 'ALL' | GalleryCategory;
+
+const FILTER_KEYS: Record<Filter, string> = {
+  ALL: 'gallery.all',
+  FOOD: 'gallery.food',
+  INTERIOR: 'gallery.interior',
+  GARDEN: 'gallery.garden',
+  EVENTS: 'gallery.events',
+};
+
+const FILTERS: Filter[] = ['ALL', 'FOOD', 'INTERIOR', 'GARDEN', 'EVENTS'];
+
+export default function Gallery() {
+  const { t } = useTranslation();
+  const { data: images, error, isLoading } = useApi<GalleryImage[]>('/api/gallery');
+  const [filter, setFilter] = useState<Filter>('ALL');
+  const [lightbox, setLightbox] = useState<GalleryImage | null>(null);
+
+  const filtered = useMemo(() => {
+    if (!images) return [];
+    if (filter === 'ALL') return images;
+    return images.filter((img) => img.category === filter);
+  }, [images, filter]);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">{t('gallery.title')}</h1>
+        <p className="mt-3 text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">{t('gallery.subtitle')}</p>
+      </div>
+
+      {/* Filter chips */}
+      <div className="flex flex-wrap justify-center gap-2 mb-8">
+        {FILTERS.map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-4 py-1.5 text-sm font-medium rounded-full transition-colors ${
+              filter === f
+                ? 'bg-primary-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+            }`}
+            aria-pressed={filter === f}
+          >
+            {t(FILTER_KEYS[f])}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && (
+        <div className="flex justify-center py-12">
+          <div className="w-8 h-8 border-4 border-primary-200 border-t-primary-600 rounded-full animate-spin" role="status" aria-label="Loading" />
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-50 text-red-700 p-4 rounded-lg text-center">
+          {t('common.error')}
+        </div>
+      )}
+
+      {!isLoading && !error && filtered.length === 0 && (
+        <p className="text-center text-gray-500 py-12">{t('gallery.empty')}</p>
+      )}
+
+      {filtered.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((img) => (
+            <button
+              key={img.id}
+              onClick={() => setLightbox(img)}
+              className="group relative overflow-hidden rounded-xl aspect-[4/3] bg-gray-100 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              aria-label={img.alt}
+            >
+              <img
+                src={img.url}
+                alt={img.alt}
+                loading="lazy"
+                className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+              <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent p-4 opacity-0 group-hover:opacity-100 transition-opacity">
+                <p className="text-white text-sm font-medium">{img.alt}</p>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {lightbox && (
+        <div
+          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+          onClick={() => setLightbox(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-label={lightbox.alt}
+        >
+          <button
+            onClick={() => setLightbox(null)}
+            className="absolute top-4 right-4 text-white p-2 rounded-full hover:bg-white/10"
+            aria-label="Close"
+          >
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <img
+            src={lightbox.url}
+            alt={lightbox.alt}
+            className="max-w-full max-h-full rounded-lg object-contain"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/storefront/src/templates/headers/ElegantHeader.tsx
+++ b/packages/storefront/src/templates/headers/ElegantHeader.tsx
@@ -18,6 +18,7 @@ export default function ElegantHeader() {
     { to: '/', label: t('nav.home') },
     { to: '/locations', label: t('nav.locations') },
     { to: '/menu', label: t('nav.menu') },
+    { to: '/gallery', label: t('nav.gallery') },
     { to: '/reservations', label: t('nav.reservations') },
   ];
 

--- a/packages/storefront/src/templates/headers/useHeaderProps.ts
+++ b/packages/storefront/src/templates/headers/useHeaderProps.ts
@@ -17,6 +17,7 @@ export function useHeaderProps() {
     { to: '/', label: t('nav.home') },
     { to: '/locations', label: t('nav.locations') },
     { to: '/menu', label: t('nav.menu') },
+    { to: '/gallery', label: t('nav.gallery') },
     { to: '/reservations', label: t('nav.reservations') },
   ];
 

--- a/prisma/migrations/20260514100737_add_gallery_images/migration.sql
+++ b/prisma/migrations/20260514100737_add_gallery_images/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "GalleryCategory" AS ENUM ('FOOD', 'INTERIOR', 'GARDEN', 'EVENTS');
+
+-- CreateTable
+CREATE TABLE "gallery_images" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "alt" TEXT NOT NULL,
+    "category" "GalleryCategory" NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "gallery_images_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "gallery_images_category_sortOrder_idx" ON "gallery_images"("category", "sortOrder");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -606,6 +606,27 @@ model SiteSettings {
   @@map("site_settings")
 }
 
+enum GalleryCategory {
+  FOOD
+  INTERIOR
+  GARDEN
+  EVENTS
+}
+
+model GalleryImage {
+  id        String          @id @default(cuid())
+  url       String
+  alt       String
+  category  GalleryCategory
+  sortOrder Int             @default(0)
+  isActive  Boolean         @default(true)
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+
+  @@index([category, sortOrder])
+  @@map("gallery_images")
+}
+
 // ============================================================
 // AUTOMATION
 // ============================================================

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -687,6 +687,42 @@ KitchenAsty Management Team`,
     });
   }
 
+  // Gallery images
+  const galleryImages = [
+    // FOOD
+    { url: 'https://images.unsplash.com/photo-1565557623262-b51c2513a641?w=1200&q=80&auto=format&fit=crop', alt: 'Butter chicken with naan', category: 'FOOD', sortOrder: 0 },
+    { url: 'https://images.unsplash.com/photo-1631452180519-c014fe946bc7?w=1200&q=80&auto=format&fit=crop', alt: 'Aromatic biryani platter', category: 'FOOD', sortOrder: 1 },
+    { url: 'https://images.unsplash.com/photo-1567188040759-fb8a883dc6d8?w=1200&q=80&auto=format&fit=crop', alt: 'Traditional Indian curry', category: 'FOOD', sortOrder: 2 },
+    { url: 'https://images.unsplash.com/photo-1601050690597-df0568f70950?w=1200&q=80&auto=format&fit=crop', alt: 'Tandoori starters platter', category: 'FOOD', sortOrder: 3 },
+    // INTERIOR
+    { url: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?w=1200&q=80&auto=format&fit=crop', alt: 'Warm dining room', category: 'INTERIOR', sortOrder: 0 },
+    { url: 'https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1200&q=80&auto=format&fit=crop', alt: 'Cocktail bar at dusk', category: 'INTERIOR', sortOrder: 1 },
+    { url: 'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1200&q=80&auto=format&fit=crop', alt: 'Candlelit table for two', category: 'INTERIOR', sortOrder: 2 },
+    // GARDEN
+    { url: 'https://images.unsplash.com/photo-1499028344343-cd173ffc68a9?w=1200&q=80&auto=format&fit=crop', alt: 'Lush garden seating', category: 'GARDEN', sortOrder: 0 },
+    { url: 'https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?w=1200&q=80&auto=format&fit=crop', alt: 'Outdoor terrace at golden hour', category: 'GARDEN', sortOrder: 1 },
+    { url: 'https://images.unsplash.com/photo-1533777324565-a040eb52facd?w=1200&q=80&auto=format&fit=crop', alt: 'Garden patio with string lights', category: 'GARDEN', sortOrder: 2 },
+    // EVENTS
+    { url: 'https://images.unsplash.com/photo-1530103862676-de8c9debad1d?w=1200&q=80&auto=format&fit=crop', alt: 'Private dining setup', category: 'EVENTS', sortOrder: 0 },
+    { url: 'https://images.unsplash.com/photo-1519671482749-fd09be7ccebf?w=1200&q=80&auto=format&fit=crop', alt: 'Celebration dinner table', category: 'EVENTS', sortOrder: 1 },
+    { url: 'https://images.unsplash.com/photo-1555244162-803834f70033?w=1200&q=80&auto=format&fit=crop', alt: 'Group toast at the bar', category: 'EVENTS', sortOrder: 2 },
+  ] as const;
+
+  for (const img of galleryImages) {
+    const seedId = `seed-gallery-${img.category}-${img.sortOrder}`;
+    await prisma.galleryImage.upsert({
+      where: { id: seedId },
+      update: { url: img.url, alt: img.alt },
+      create: {
+        id: seedId,
+        url: img.url,
+        alt: img.alt,
+        category: img.category,
+        sortOrder: img.sortOrder,
+      },
+    });
+  }
+
   console.log('Seed completed successfully!');
   console.log('');
   console.log('Admin login: admin@kitchenasty.com / admin123');


### PR DESCRIPTION
## Summary

- Adds a public photo gallery to the storefront at `/gallery` with category filter chips (Food, Interior, Garden, Events) and a lightbox modal.
- Adds the **Gallery** link to all storefront header variants and the i18n strings across 6 locales (en, de, es, fr, it, pt).
- New `GalleryImage` Prisma model + migration, backed by a public `GET /api/gallery` endpoint and staff-only CRUD endpoints.
- New admin page **Design → Gallery** for managing images: add, edit, hide/show, reorder, delete.
- Seeds ~13 sample images across the four categories so the page is populated out of the box.

Covers item 2 of the Moksha post-pitch backlog (website gallery section).

## Test plan

- [ ] Visit `/gallery` on the storefront → grid renders, category chips filter, clicking an image opens lightbox
- [ ] Switch languages via the storefront language switcher → category labels and subtitle translate
- [ ] In admin, navigate to **Design → Gallery** → list shows all images grouped by category
- [ ] Add a new image via the form → appears on storefront immediately
- [ ] Hide an image in admin → it disappears from storefront
- [ ] Delete an image → confirms via dialog and removes from both

🤖 Generated with [Claude Code](https://claude.com/claude-code)