### PR TITLE
feat(admin): add media library with uploads and reusable picker

### DIFF
--- a/packages/admin/src/components/AdminLayout.tsx
+++ b/packages/admin/src/components/AdminLayout.tsx
@@ -52,6 +52,7 @@ const navItems: NavItem[] = [
       { path: '/design/theme', label: 'Theme' },
       { path: '/design/templates', label: 'Templates' },
       { path: '/design/gallery', label: 'Gallery' },
+      { path: '/design/media', label: 'Media Library' },
     ],
   },
   {

--- a/packages/admin/src/components/MediaPicker.tsx
+++ b/packages/admin/src/components/MediaPicker.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+
+export interface MediaAsset {
+  id: string;
+  filename: string;
+  originalName: string;
+  url: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  uploadedBy?: { id: string; name: string } | null;
+}
+
+export function MediaPickerModal({
+  open,
+  onClose,
+  onPick,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onPick: (asset: MediaAsset) => void;
+}) {
+  const [items, setItems] = useState<MediaAsset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [uploading, setUploading] = useState(false);
+
+  const token = localStorage.getItem('token') || '';
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/media?limit=100', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const result = await res.json();
+      if (!res.ok) throw new Error(result.error || 'Failed to load');
+      setItems(result.data ?? []);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (open) load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError('');
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/media/upload', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+      const result = await res.json();
+      if (!res.ok) throw new Error(result.error || 'Upload failed');
+      await load();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick from media library"
+    >
+      <div
+        className="bg-white rounded-xl shadow-xl max-w-4xl w-full max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Pick from Media Library</h3>
+          <div className="flex items-center gap-3">
+            <label className="px-3 py-1.5 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 cursor-pointer">
+              {uploading ? 'Uploading...' : '+ Upload New'}
+              <input type="file" accept="image/*" onChange={handleUpload} className="hidden" disabled={uploading} />
+            </label>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 p-1"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {error && <div className="bg-red-50 text-red-700 p-3 rounded-lg mb-4 text-sm">{error}</div>}
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <div className="w-8 h-8 border-4 border-primary-200 border-t-primary-600 rounded-full animate-spin" />
+            </div>
+          ) : items.length === 0 ? (
+            <p className="text-center text-gray-500 py-12 text-sm">
+              No uploads yet. Click "Upload New" to add an image.
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+              {items.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => onPick(item)}
+                  className="group relative aspect-square bg-gray-100 rounded-lg overflow-hidden border-2 border-transparent hover:border-primary-500 focus:outline-none focus:border-primary-500"
+                  title={item.originalName}
+                >
+                  <img src={item.url} alt={item.originalName} className="w-full h-full object-cover" loading="lazy" />
+                  <div className="absolute inset-0 bg-primary-600/0 group-hover:bg-primary-600/20 transition-colors flex items-center justify-center">
+                    <span className="opacity-0 group-hover:opacity-100 bg-primary-600 text-white text-xs font-semibold px-2 py-1 rounded">
+                      Select
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -35,6 +35,7 @@ import DesignBranding from './pages/DesignBranding.js';
 import DesignTheme from './pages/DesignTheme.js';
 import DesignTemplates from './pages/DesignTemplates.js';
 import DesignGallery from './pages/DesignGallery.js';
+import DesignMedia from './pages/DesignMedia.js';
 import StaffList from './pages/StaffList.js';
 import StaffInvite from './pages/StaffInvite.js';
 import StaffEdit from './pages/StaffEdit.js';
@@ -110,6 +111,7 @@ function AppRoutes() {
         <Route path="/design/theme" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignTheme /></RequireRole>} />
         <Route path="/design/templates" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignTemplates /></RequireRole>} />
         <Route path="/design/gallery" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignGallery /></RequireRole>} />
+        <Route path="/design/media" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><DesignMedia /></RequireRole>} />
         <Route path="/legal" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><Navigate to="/legal/pages" replace /></RequireRole>} />
         <Route path="/legal/pages" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><LegalPageList /></RequireRole>} />
         <Route path="/legal/pages/:slug" element={<RequireRole roles={['SUPER_ADMIN', 'MANAGER']}><LegalPageForm /></RequireRole>} />

--- a/packages/admin/src/pages/DesignMedia.tsx
+++ b/packages/admin/src/pages/DesignMedia.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MediaAsset } from '../components/MediaPicker.js';
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function DesignMedia() {
+  const [items, setItems] = useState<MediaAsset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const token = localStorage.getItem('token') || '';
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/media?limit=100', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const result = await res.json();
+      if (!res.ok) throw new Error(result.error || 'Failed to load media');
+      setItems(result.data ?? []);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function uploadFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setUploading(true);
+    setError('');
+    try {
+      for (const file of Array.from(files)) {
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await fetch('/api/media/upload', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: formData,
+        });
+        if (!res.ok) {
+          const result = await res.json().catch(() => ({}));
+          throw new Error(result.error || `Upload failed for ${file.name}`);
+        }
+      }
+      await load();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  async function remove(item: MediaAsset) {
+    if (!window.confirm(`Delete "${item.originalName}"? This will remove the file from storage.`)) return;
+    const res = await fetch(`/api/media/${item.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) await load();
+    else setError('Delete failed');
+  }
+
+  async function copyUrl(item: MediaAsset) {
+    const fullUrl = `${window.location.origin}${item.url}`;
+    try {
+      await navigator.clipboard.writeText(fullUrl);
+      setCopiedId(item.id);
+      setTimeout(() => setCopiedId((id) => (id === item.id ? null : id)), 1500);
+    } catch {
+      setError('Could not copy to clipboard');
+    }
+  }
+
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    uploadFiles(e.dataTransfer.files);
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-800">Media Library</h2>
+          <p className="text-sm text-gray-500 mt-1">Upload and manage images used across your storefront</p>
+        </div>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          className="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+        >
+          {uploading ? 'Uploading...' : '+ Upload Image'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={(e) => uploadFiles(e.target.files)}
+          className="hidden"
+        />
+      </div>
+
+      {/* Drop zone */}
+      <div
+        onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={onDrop}
+        className={`mb-6 border-2 border-dashed rounded-xl p-8 text-center transition-colors ${
+          dragOver ? 'border-primary-500 bg-primary-50' : 'border-gray-300 bg-gray-50'
+        }`}
+      >
+        <p className="text-sm text-gray-600">
+          Drag and drop images here, or click <span className="font-semibold">Upload Image</span> above.
+        </p>
+        <p className="text-xs text-gray-400 mt-1">JPEG, PNG, WebP or GIF · max 5 MB each</p>
+      </div>
+
+      {error && <div className="bg-red-50 text-red-700 p-3 rounded-lg mb-4 text-sm">{error}</div>}
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <div className="w-8 h-8 border-4 border-primary-200 border-t-primary-600 rounded-full animate-spin" />
+        </div>
+      ) : items.length === 0 ? (
+        <p className="text-gray-500 text-sm py-8 text-center">No images yet. Upload one to get started.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {items.map((item) => (
+            <div key={item.id} className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+              <div className="aspect-square bg-gray-100 relative">
+                <img src={item.url} alt={item.originalName} className="w-full h-full object-cover" loading="lazy" />
+              </div>
+              <div className="p-3">
+                <p className="text-sm font-medium text-gray-900 truncate" title={item.originalName}>
+                  {item.originalName}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {formatSize(item.size)} · {formatDate(item.createdAt)}
+                </p>
+                <div className="flex gap-2 mt-3">
+                  <button
+                    onClick={() => copyUrl(item)}
+                    className="flex-1 text-xs px-2 py-1.5 border border-gray-300 rounded hover:bg-gray-50"
+                  >
+                    {copiedId === item.id ? 'Copied!' : 'Copy URL'}
+                  </button>
+                  <button
+                    onClick={() => remove(item)}
+                    className="text-xs px-2 py-1.5 border border-red-200 text-red-600 rounded hover:bg-red-50"
+                    aria-label={`Delete ${item.originalName}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/server/src/__tests__/integration/media.test.ts
+++ b/packages/server/src/__tests__/integration/media.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../app.js';
+import { generateToken } from '../../middleware/auth.js';
+
+vi.mock('../../lib/db.js', () => {
+  const mockPrisma = {
+    mediaAsset: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), delete: vi.fn(), count: vi.fn() },
+    user: { findUnique: vi.fn() },
+    customer: { findUnique: vi.fn() },
+  };
+  return { default: mockPrisma, prisma: mockPrisma };
+});
+
+vi.mock('../../lib/stripe.js', () => ({
+  default: {
+    paymentIntents: { create: vi.fn() },
+    webhooks: { constructEvent: vi.fn() },
+  },
+}));
+
+// Silence the fs.unlink call in deleteMedia — file may not exist in tests
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      unlink: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+import prisma from '../../lib/db.js';
+const mockedPrisma = vi.mocked(prisma);
+
+const app = createApp();
+
+const staffToken = generateToken({ id: 'user-1', email: 'admin@test.com', type: 'staff', role: 'SUPER_ADMIN' });
+const customerToken = generateToken({ id: 'cust-1', email: 'customer@test.com', type: 'customer' });
+
+const sampleAsset = {
+  id: 'media-1',
+  filename: 'abc.jpg',
+  originalName: 'photo.jpg',
+  url: '/uploads/abc.jpg',
+  mimeType: 'image/jpeg',
+  size: 12345,
+  uploadedById: 'user-1',
+  createdAt: new Date(),
+  uploadedBy: { id: 'user-1', name: 'Admin' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Media API', () => {
+  describe('GET /api/media', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app).get('/api/media');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .get('/api/media')
+        .set('Authorization', `Bearer ${customerToken}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns paginated list for staff', async () => {
+      mockedPrisma.mediaAsset.findMany.mockResolvedValueOnce([sampleAsset] as any);
+      mockedPrisma.mediaAsset.count.mockResolvedValueOnce(1);
+      const res = await request(app)
+        .get('/api/media')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].url).toBe('/uploads/abc.jpg');
+      expect(res.body.pagination).toMatchObject({ page: 1, total: 1, totalPages: 1 });
+    });
+  });
+
+  describe('POST /api/media/upload', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app)
+        .post('/api/media/upload')
+        .attach('file', Buffer.from('fake-png-bytes'), { filename: 'test.png', contentType: 'image/png' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .post('/api/media/upload')
+        .set('Authorization', `Bearer ${customerToken}`)
+        .attach('file', Buffer.from('fake-png-bytes'), { filename: 'test.png', contentType: 'image/png' });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 400 when no file is attached', async () => {
+      const res = await request(app)
+        .post('/api/media/upload')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  describe('DELETE /api/media/:id', () => {
+    it('returns 401 without auth', async () => {
+      const res = await request(app).delete('/api/media/media-1');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-staff', async () => {
+      const res = await request(app)
+        .delete('/api/media/media-1')
+        .set('Authorization', `Bearer ${customerToken}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when not found', async () => {
+      mockedPrisma.mediaAsset.findUnique.mockResolvedValueOnce(null);
+      const res = await request(app)
+        .delete('/api/media/bad-id')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('deletes asset successfully', async () => {
+      mockedPrisma.mediaAsset.findUnique.mockResolvedValueOnce(sampleAsset as any);
+      mockedPrisma.mediaAsset.delete.mockResolvedValueOnce(sampleAsset as any);
+      const res = await request(app)
+        .delete('/api/media/media-1')
+        .set('Authorization', `Bearer ${staffToken}`);
+      expect(res.status).toBe(200);
+      expect(mockedPrisma.mediaAsset.delete).toHaveBeenCalledWith({ where: { id: 'media-1' } });
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,7 +21,7 @@ import consentRoutes from './routes/consent.routes.js';
 import settingsRoutes from './routes/settings.routes.js';
 import staffRoutes from './routes/staff.routes.js';
 import developerRoutes from './routes/developer.routes.js';
-import galleryRoutes from './routes/gallery.routes.js';
+import mediaRoutes from './routes/media.routes.js';
 import { openApiSpec } from './lib/openapi.js';
 import { initPassport } from './lib/passport.js';
 import passport from 'passport';
@@ -118,7 +118,7 @@ export function createApp() {
   app.use('/api/settings', settingsRoutes);
   app.use('/api/staff', staffRoutes);
   app.use('/api/developer', developerRoutes);
-  app.use('/api/gallery', galleryRoutes);
+  app.use('/api/media', mediaRoutes);
 
   // 404 handler
   app.use((_req, res) => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,6 +21,7 @@ import consentRoutes from './routes/consent.routes.js';
 import settingsRoutes from './routes/settings.routes.js';
 import staffRoutes from './routes/staff.routes.js';
 import developerRoutes from './routes/developer.routes.js';
+import galleryRoutes from './routes/gallery.routes.js';
 import mediaRoutes from './routes/media.routes.js';
 import { openApiSpec } from './lib/openapi.js';
 import { initPassport } from './lib/passport.js';
@@ -118,6 +119,7 @@ export function createApp() {
   app.use('/api/settings', settingsRoutes);
   app.use('/api/staff', staffRoutes);
   app.use('/api/developer', developerRoutes);
+  app.use('/api/gallery', galleryRoutes);
   app.use('/api/media', mediaRoutes);
 
   // 404 handler

--- a/packages/server/src/controllers/media.controller.ts
+++ b/packages/server/src/controllers/media.controller.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import prisma from '../lib/db.js';
+
+const UPLOADS_DIR = path.resolve(process.cwd(), 'uploads');
+
+export async function uploadMedia(req: Request, res: Response): Promise<void> {
+  if (!req.file) {
+    res.status(400).json({ success: false, error: 'No file provided' });
+    return;
+  }
+
+  const userId = (req as any).user?.id ?? null;
+
+  const asset = await prisma.mediaAsset.create({
+    data: {
+      filename: req.file.filename,
+      originalName: req.file.originalname,
+      url: `/uploads/${req.file.filename}`,
+      mimeType: req.file.mimetype,
+      size: req.file.size,
+      uploadedById: userId,
+    },
+  });
+
+  res.status(201).json({ success: true, data: asset });
+}
+
+export async function listMedia(req: Request, res: Response): Promise<void> {
+  const page = Math.max(1, parseInt(req.query.page as string) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 50));
+  const skip = (page - 1) * limit;
+
+  const [items, total] = await Promise.all([
+    prisma.mediaAsset.findMany({
+      skip,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      include: { uploadedBy: { select: { id: true, name: true } } },
+    }),
+    prisma.mediaAsset.count(),
+  ]);
+
+  res.json({
+    success: true,
+    data: items,
+    pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+  });
+}
+
+export async function deleteMedia(req: Request<{ id: string }>, res: Response): Promise<void> {
+  const asset = await prisma.mediaAsset.findUnique({ where: { id: req.params.id } });
+  if (!asset) {
+    res.status(404).json({ success: false, error: 'Media not found' });
+    return;
+  }
+
+  const filePath = path.join(UPLOADS_DIR, asset.filename);
+  try {
+    await fs.unlink(filePath);
+  } catch {
+    // file may already be gone — keep going to remove the DB row
+  }
+
+  await prisma.mediaAsset.delete({ where: { id: req.params.id } });
+  res.json({ success: true, message: 'Media deleted' });
+}

--- a/packages/server/src/routes/media.routes.ts
+++ b/packages/server/src/routes/media.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { authenticate, requireStaff } from '../middleware/auth.js';
+import { upload } from '../middleware/upload.js';
+import { uploadMedia, listMedia, deleteMedia } from '../controllers/media.controller.js';
+
+const router = Router();
+
+router.get('/', authenticate, requireStaff, listMedia);
+router.post('/upload', authenticate, requireStaff, upload.single('file'), uploadMedia);
+router.delete('/:id', authenticate, requireStaff, deleteMedia);
+
+export default router;

--- a/prisma/migrations/20260514101500_add_media_assets/migration.sql
+++ b/prisma/migrations/20260514101500_add_media_assets/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "media_assets" (
+    "id" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "uploadedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "media_assets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "media_assets_createdAt_idx" ON "media_assets"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "media_assets" ADD CONSTRAINT "media_assets_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   location   Location? @relation(fields: [locationId], references: [id])
 
   assignedOrders Order[] @relation("AssignedStaff")
+  mediaAssets    MediaAsset[]
 
   @@map("users")
 }
@@ -625,6 +626,21 @@ model GalleryImage {
 
   @@index([category, sortOrder])
   @@map("gallery_images")
+}
+
+model MediaAsset {
+  id           String   @id @default(cuid())
+  filename     String
+  originalName String
+  url          String
+  mimeType     String
+  size         Int
+  uploadedById String?
+  uploadedBy   User?    @relation(fields: [uploadedById], references: [id], onDelete: SetNull)
+  createdAt    DateTime @default(now())
+
+  @@index([createdAt])
+  @@map("media_assets")
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Adds a Media Library page at `/design/media` with drag-and-drop upload, multi-select uploads, copy-URL action, and delete.
- Files are stored locally under `/uploads` (already served by the server) and indexed in a new `MediaAsset` table that captures filename, original name, MIME type, size, and uploader.
- Ships a reusable `MediaPickerModal` component so other admin forms (gallery, hero, menu items, banners) can adopt it incrementally without re-implementing the listing/upload flow.

Covers item 3 of the Moksha post-pitch backlog (image upload + media library).

**New endpoints** (staff-only):
- `GET    /api/media` — paginated list
- `POST   /api/media/upload` — multipart upload (5 MB, image only)
- `DELETE /api/media/:id` — removes DB row + underlying file

## Test plan

- [ ] Navigate to **Design → Media Library** in admin
- [ ] Drag an image onto the drop zone — appears in the grid after upload
- [ ] Click "Upload Image" + select multiple files — all upload
- [ ] Click "Copy URL" — full URL copied, button shows "Copied!" feedback
- [ ] Delete an image — confirms via dialog, then disappears from grid and `uploads/` folder
- [ ] Upload an oversized (>5 MB) or non-image file — gracefully fails with an error message

## Follow-ups

- Wire `MediaPickerModal` into the gallery admin form (F2's `DesignGallery`) to replace the manual URL paste with a "Pick from library" button.
- Same for menu item images, hero background, branding logo, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)