### PR TITLE
feat(payment): Stripe PaymentIntents in EUR + receipt_email + auto methods

### DIFF
--- a/packages/server/src/controllers/payment.controller.ts
+++ b/packages/server/src/controllers/payment.controller.ts
@@ -11,7 +11,10 @@ export async function createPaymentIntent(req: Request, res: Response): Promise<
     return;
   }
 
-  const order = await prisma.order.findUnique({ where: { id: orderId } });
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    include: { customer: { select: { email: true, name: true } } },
+  });
   if (!order) {
     res.status(404).json({ success: false, error: 'Order not found' });
     return;
@@ -26,14 +29,24 @@ export async function createPaymentIntent(req: Request, res: Response): Promise<
     return;
   }
 
+  // Use the registered customer's email when present, fall back to the
+  // guest-checkout email — both produce Stripe receipt emails + show up
+  // attached to the PaymentIntent in the dashboard.
+  const receiptEmail = order.customer?.email ?? order.guestEmail ?? undefined;
+
   try {
     const stripe = await getStripe();
     const paymentIntent = await stripe.paymentIntents.create({
       amount: Math.round(order.total * 100), // cents
-      currency: 'usd',
+      currency: 'eur',
+      receipt_email: receiptEmail,
+      // Let Stripe pick which payment methods to surface — covers cards,
+      // Apple Pay and Google Pay on PaymentSheet without extra config.
+      automatic_payment_methods: { enabled: true },
       metadata: {
         orderId: order.id,
         orderNumber: order.orderNumber,
+        customerName: order.customer?.name ?? order.guestName ?? '',
       },
     });
 


### PR DESCRIPTION
## Summary
- `createPaymentIntent` switches currency from `usd` → `eur`
- Includes `receipt_email` (registered customer or guest) so Stripe sends an automatic receipt
- Enables `automatic_payment_methods` so PaymentSheet surfaces cards + Apple Pay + Google Pay without per-method client config
- Adds `customerName` + `orderNumber` + `orderId` to PaymentIntent metadata

## Why
Powers the new Flutter Stripe checkout in `inka-mobile` against the inka.kitchenasty.com test deployment. Webhook handler (already in tree) flips `Order.status` to `CONFIRMED` on `payment_intent.succeeded`.

## Test plan
- [ ] Deploy as `inka-v0.5.0` via Orca (separate orca-infra PR)
- [ ] curl POST `/api/payment/create-intent` with a real test order id → returns `clientSecret`
- [ ] App PaymentSheet completes with test card `4242 4242 4242 4242`
- [ ] Webhook fires `payment_intent.succeeded` → order flips to CONFIRMED
- [ ] Stripe Dashboard shows the receipt sent to the customer email

🤖 Generated with [Claude Code](https://claude.com/claude-code)