### PR TITLE
feat(payment): website Stripe Checkout (hosted) + EUR-formatted confirmation

### DIFF
--- a/packages/server/src/controllers/payment.controller.ts
+++ b/packages/server/src/controllers/payment.controller.ts
@@ -70,6 +70,106 @@ export async function createPaymentIntent(req: Request, res: Response): Promise<
   }
 }
 
+/// Creates a Stripe Checkout Session for the order. The customer is
+/// redirected to Stripe's hosted page (cards + Apple Pay + Google Pay +
+/// Klarna + SEPA come for free), and Stripe redirects back to the
+/// order-confirmation page on success.
+///
+/// We attach `orderId` to BOTH the session metadata and the underlying
+/// payment intent so the existing `payment_intent.succeeded` webhook
+/// path still flips Order.status — the new `checkout.session.completed`
+/// case below is just a belt-and-braces.
+export async function createCheckoutSession(req: Request, res: Response): Promise<void> {
+  const { orderId } = req.body;
+  if (!orderId) {
+    res.status(400).json({ success: false, error: 'orderId is required' });
+    return;
+  }
+
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    include: {
+      customer: { select: { email: true } },
+      items: true,
+    },
+  });
+  if (!order) {
+    res.status(404).json({ success: false, error: 'Order not found' });
+    return;
+  }
+
+  const existingPayment = await prisma.payment.findFirst({
+    where: { orderId, status: 'COMPLETED' },
+  });
+  if (existingPayment) {
+    res.status(409).json({ success: false, error: 'Order already paid' });
+    return;
+  }
+
+  const publicUrl = process.env.PUBLIC_URL || 'https://inka.kitchenasty.com';
+  const customerEmail = order.customer?.email ?? order.guestEmail ?? undefined;
+
+  try {
+    const stripe = await getStripe();
+
+    const lineItems = order.items.map((it) => ({
+      price_data: {
+        currency: 'eur',
+        product_data: { name: it.name },
+        unit_amount: Math.round(it.unitPrice * 100),
+      },
+      quantity: it.quantity,
+    }));
+
+    if (order.deliveryFee > 0) {
+      lineItems.push({
+        price_data: {
+          currency: 'eur',
+          product_data: { name: 'Delivery fee' },
+          unit_amount: Math.round(order.deliveryFee * 100),
+        },
+        quantity: 1,
+      });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: lineItems,
+      success_url: `${publicUrl}/order/${order.id}?paid=true`,
+      cancel_url: `${publicUrl}/checkout`,
+      customer_email: customerEmail,
+      metadata: {
+        orderId: order.id,
+        orderNumber: order.orderNumber,
+      },
+      payment_intent_data: {
+        receipt_email: customerEmail,
+        metadata: {
+          orderId: order.id,
+          orderNumber: order.orderNumber,
+        },
+      },
+    });
+
+    await prisma.payment.create({
+      data: {
+        orderId: order.id,
+        method: 'STRIPE',
+        status: 'PENDING',
+        amount: order.total,
+        transactionId: session.id,
+      },
+    });
+
+    res.json({
+      success: true,
+      data: { url: session.url, sessionId: session.id },
+    });
+  } catch (err: any) {
+    res.status(500).json({ success: false, error: err.message || 'Checkout session creation failed' });
+  }
+}
+
 export async function handleWebhook(req: Request, res: Response): Promise<void> {
   const sig = req.headers['stripe-signature'] as string;
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -115,6 +215,26 @@ export async function handleWebhook(req: Request, res: Response): Promise<void> 
         where: { transactionId: paymentIntent.id },
         data: { status: 'FAILED' },
       });
+      break;
+    }
+
+    case 'checkout.session.completed': {
+      // Stripe Checkout (hosted) finished. payment_intent.succeeded also
+      // fires for the same flow, but the session event lets us mark the
+      // Payment row (whose transactionId is the session.id) as completed
+      // and gives us a second chance to flip Order.status.
+      const session = event.data.object as { id: string; payment_status?: string; metadata?: { orderId?: string } };
+      const orderId = session.metadata?.orderId;
+      if (orderId && session.payment_status === 'paid') {
+        await prisma.payment.updateMany({
+          where: { transactionId: session.id },
+          data: { status: 'COMPLETED' },
+        });
+        await prisma.order.update({
+          where: { id: orderId },
+          data: { status: 'CONFIRMED' },
+        });
+      }
       break;
     }
   }

--- a/packages/server/src/routes/payment.routes.ts
+++ b/packages/server/src/routes/payment.routes.ts
@@ -1,15 +1,18 @@
 import { Router } from 'express';
 import express from 'express';
 import { optionalAuth, authenticate, requireStaff } from '../middleware/auth.js';
-import { createPaymentIntent, handleWebhook, markCashPayment, createPayPalPayment, capturePayPalPayment } from '../controllers/payment.controller.js';
+import { createPaymentIntent, createCheckoutSession, handleWebhook, markCashPayment, createPayPalPayment, capturePayPalPayment } from '../controllers/payment.controller.js';
 
 const router = Router();
 
 // Stripe webhook needs raw body
 router.post('/webhook', express.raw({ type: 'application/json' }), handleWebhook);
 
-// Create payment intent (customer or guest)
+// PaymentIntent (mobile app — flutter_stripe PaymentSheet)
 router.post('/create-intent', optionalAuth, createPaymentIntent);
+
+// Checkout Session (website — hosted Stripe page)
+router.post('/create-checkout-session', optionalAuth, createCheckoutSession);
 
 // Mark cash payment (staff only)
 router.post('/cash', authenticate, requireStaff, markCashPayment);

--- a/packages/storefront/src/pages/Checkout.tsx
+++ b/packages/storefront/src/pages/Checkout.tsx
@@ -142,8 +142,30 @@ export default function Checkout() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to place order');
 
+      const orderId = data.data.id as string;
+
+      // Stripe path: hand the user off to the hosted Checkout page. Stripe
+      // brings them back to /order/:id?paid=true on success (the webhook
+      // is what actually flips Order.status). Cancel falls back to /checkout.
+      if (paymentMethod === 'stripe') {
+        const sessRes = await fetch('/api/payments/create-checkout-session', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ orderId }),
+        });
+        const sessData = await sessRes.json();
+        if (!sessRes.ok || !sessData.data?.url) {
+          throw new Error(sessData.error || 'Failed to start Stripe checkout');
+        }
+        // Don't clear the cart yet — only after Stripe confirms. If the
+        // user backs out of the hosted page, they return to a still-loaded
+        // checkout and can retry without re-typing everything.
+        window.location.href = sessData.data.url as string;
+        return;
+      }
+
       clear();
-      navigate(`/order/${data.data.id}`, { state: { order: data.data } });
+      navigate(`/order/${orderId}`, { state: { order: data.data } });
     } catch (err: any) {
       setError(err.message || t('common.error'));
     } finally {

--- a/packages/storefront/src/pages/OrderConfirmation.tsx
+++ b/packages/storefront/src/pages/OrderConfirmation.tsx
@@ -1,11 +1,68 @@
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useCart } from '../context/CartContext.js';
+
+type Order = {
+  id: string;
+  orderNumber?: string;
+  orderType?: string;
+  status?: string;
+  subtotal?: number;
+  total?: number;
+};
+
+const eur = (v: number | undefined) =>
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(v ?? 0);
 
 export default function OrderConfirmation() {
   const { t } = useTranslation();
   const { id } = useParams();
   const location = useLocation();
-  const order = location.state?.order;
+  const [search] = useSearchParams();
+  const { clear } = useCart();
+
+  const paid = search.get('paid') === 'true';
+  const initial = (location.state?.order as Order | undefined) ?? null;
+  const [order, setOrder] = useState<Order | null>(initial);
+  const [polls, setPolls] = useState(0);
+
+  // First visit with ?paid=true (Stripe redirected back). Clear the cart
+  // — we kept it loaded across the Stripe hop in case the user cancelled.
+  useEffect(() => {
+    if (paid) clear();
+  }, [paid, clear]);
+
+  // Refetch the order from the API if we landed here without state (the
+  // Stripe redirect drops it) or if the order is still PENDING — the
+  // webhook can take a second or two after success.
+  useEffect(() => {
+    if (!id) return;
+    if (order && order.status === 'CONFIRMED') return;
+    if (polls > 10) return;
+
+    let cancelled = false;
+    const t = setTimeout(
+      async () => {
+        try {
+          const res = await fetch(`/api/orders/${id}`);
+          if (!res.ok) return;
+          const data = await res.json();
+          if (!cancelled && data?.data) setOrder(data.data as Order);
+          setPolls((n) => n + 1);
+        } catch {
+          /* noop */
+        }
+      },
+      polls === 0 ? 0 : 1500,
+    );
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [id, order, polls]);
+
+  const confirmed = order?.status === 'CONFIRMED';
 
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
@@ -17,6 +74,10 @@ export default function OrderConfirmation() {
 
       <h1 className="text-3xl font-bold text-gray-900 mb-2">{t('orderConfirmation.title')}</h1>
       <p className="text-gray-600 mb-2">{t('orderConfirmation.thankYou')}</p>
+
+      {paid && !confirmed && (
+        <p className="text-sm text-gray-500 mb-2">Finalising your payment…</p>
+      )}
 
       {(order?.orderNumber || id) && (
         <p className="text-sm text-gray-500 mb-6">
@@ -37,11 +98,11 @@ export default function OrderConfirmation() {
             </div>
             <div>
               <span className="text-gray-500">{t('checkout.subtotal')}</span>
-              <p className="font-medium text-gray-900">${order.subtotal?.toFixed(2)}</p>
+              <p className="font-medium text-gray-900">{eur(order.subtotal)}</p>
             </div>
             <div>
               <span className="text-gray-500">{t('checkout.total')}</span>
-              <p className="font-bold text-primary-600">${order.total?.toFixed(2)}</p>
+              <p className="font-bold text-primary-600">{eur(order.total)}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Server: new `/api/payments/create-checkout-session` endpoint creating Stripe-hosted Checkout sessions; webhook also handles `checkout.session.completed`
- Storefront: `Checkout.tsx` redirects to the hosted page when paymentMethod === 'stripe'; `OrderConfirmation.tsx` refetches + polls the order so the page reflects `CONFIRMED` after webhook fires
- Currency display switched `$` → € on the confirmation page

## Why
Previously the website created PENDING orders without ever collecting a card. Stripe never saw the order; no money moved.

## Test plan
- [ ] Place order on inka.kitchenasty.com with Stripe selected
- [ ] Verify redirect to hosted Stripe page
- [ ] Pay with 4242 4242 4242 4242
- [ ] Land on /order/:id?paid=true with order = CONFIRMED within ~3s
- [ ] Cancel from Stripe → returns to /checkout with cart still loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)